### PR TITLE
本番用画像ストレージAmazonS3配置設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM base as build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3 imagemagick
 
 # Install JavaScript dependencies
 ARG NODE_VERSION=20.14.0
@@ -55,7 +55,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl imagemagick libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,10 @@ gem "dockerfile-rails", ">= 1.6", :group => :development
 
 gem 'dotenv'
 
-gem 'image_processing', '~> 1.0'
-gem 'carrierwave', '~> 3.0'
+gem 'image_processing'
+gem 'carrierwave'
+gem 'fog-aws'
+gem 'mini_magick'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,11 +114,33 @@ GEM
     dotenv (3.1.2)
     drb (2.2.1)
     erubi (1.13.0)
+    excon (0.111.0)
     faraday (2.9.1)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.24.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -148,10 +170,14 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -306,14 +332,16 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
-  carrierwave (~> 3.0)
+  carrierwave
   cssbundling-rails
   debug
   dockerfile-rails (>= 1.6)
   dotenv
-  image_processing (~> 1.0)
+  fog-aws
+  image_processing
   jbuilder
   jsbundling-rails
+  mini_magick
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)

--- a/app/uploaders/board_image_uploader.rb
+++ b/app/uploaders/board_image_uploader.rb
@@ -2,8 +2,12 @@ class BoardImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  # if Rails.env.production?
+  storage :fog
+  #else
+  #  storage :file
+  #end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'journalip-bucket'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1',
+      path_style: true
+    }
+end


### PR DESCRIPTION
本番環境での投稿に添付された画像はAmazonS3に保存されるように設定

carrierwaveで以下設定
・carrierwaveのアップローダー``app/uploaders/board_image_uploader.rb``のストレージを``storage :fog``へ変更
・``config/initializers/carrierwave.rb``を作成し、S3への保存設定記載

Dockerfile
・ImageMagickをインストールするコードの追加

gem
・依存関係の整理