### PR TITLE
地図機能実装 part1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'rails-i18n', '~> 7.0.0'
 
 gem "meta-tags"
 
+gem "geocoder"
+
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -141,6 +142,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -343,6 +347,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv
   fog-aws
+  geocoder
   image_processing
   jbuilder
   jsbundling-rails

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -51,7 +51,7 @@ class BoardsController < ApplicationController
   end
 
   def board_params
-    params.require(:board).permit(:title, :opinion, :background, :emotion, :value, :board_image, :board_image_cache)
+    params.require(:board).permit(:title, :opinion, :background, :emotion, :value, :board_image, :board_image_cache, :place)
   end
 end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import './place_autocomplete.js'

--- a/app/javascript/place_autocomplete.js
+++ b/app/javascript/place_autocomplete.js
@@ -1,0 +1,20 @@
+// Place Autocomplete
+document.addEventListener('DOMContentLoaded', function () {
+    const inputPlace = document.getElementById('Place');
+  
+    // オートコンプリートのオプション
+    const options = {
+      types: ['geocode'],
+      componentRestrictions: { country: 'JP' },
+    };
+  
+    // オートコンプリート適用
+    const autocompletePlace = new google.maps.places.Autocomplete(inputPlace, options);
+  
+    // タイトルのオートコンプリートが選択されたとき
+    autocompletePlace.addListener('place_changed', function() {
+      const place = autocompletePlace.getPlace();
+      inputPlace.value = place.formatted_address;
+    });
+  });
+  

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2,6 +2,10 @@ class Board < ApplicationRecord
   mount_uploader :board_image, BoardImageUploader
   belongs_to :user
 
+  # placeフィールドから緯度と経度を取得するためにgeocoderを設定
+  geocoded_by :place
+  after_validation :geocode, if: :place_changed?
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :opinion, presence: true, length: { maximum: 65_535 }
   validates :background, presence: true, length: { maximum: 65_535 }

--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @board do |f| %>
   <div class="my-3">
     <p><%= f.label :place, '訪れた場所', class: "form-label" %></p>
-    <%= f.text_field :place, id: "place", class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）国、県、市' %>
+    <%= f.text_field :place, id: "Place", class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）国、県、市' %>
   </div>
   <div class="my-3">
     <div>
@@ -37,3 +37,5 @@
   </div>
   <%= f.submit '投稿', class: "btn btn-primary"%>
 <% end %>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize"></script>

--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,5 +1,9 @@
 <%= form_with model: @board do |f| %>
   <div class="my-3">
+    <p><%= f.label :place, '訪れた場所', class: "form-label" %></p>
+    <%= f.text_field :place, id: "place", class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）国、県、市' %>
+  </div>
+  <div class="my-3">
     <div>
       <%= f.label :board_image %>
       <%= f.file_field :board_image, class: "form-control", accept: 'image/*' %>
@@ -11,6 +15,7 @@
         </div>
       <% end %>
     </div>
+  <div class="my-3">
     <p><%= f.label :title, '旅で印象に残ったこと', class: "form-label" %></p>
     <%= f.text_field :title, class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）大阪での発見' %>
   </div>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -8,11 +8,11 @@
     <h2 class="lg:text-4xl mb-24">旅からあなたの価値観を見つけ出そう</h2>
   </div>
 
-    <h4 class="text-center text-gray-800 font-bold mb-4 md:mb-2 text-xl">あなたが大事にしていることはなんですか？</h4>
-    <article class="flex justify-center items-center text-gray-800 text-xs md:text-base">
-    <p>そう聞かれた時に、うまく言葉にならなかった経験はありませんか？<br>
-    Journalipは旅の思い出を通して、あなたらしさを言語化する練習を手伝います</p>
-    </article>
+    <h4 class="text-center text-gray-800 font-bold mx-10 mb-4 text-xl md:mb-2">あなたが大事にしていることはなんですか？</h4>
+    <div class="text-gray-800 text-xs mx-10 md:text-base md:mx-44 lg:mx-96">
+      <p>そう聞かれた時に、うまく言葉にならなかった経験はありませんか？</p>
+      <p>Journalipは旅の思い出を通して、あなたらしさを言語化する練習を手伝います</p>
+    </div>
 
     <h2 class="mt-24 text-center text-2xl font-bold text-gray-800 mb-8 text-3xl">最新記事</h2>
 <%# ここにここに最新記事６つ表示する %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # google maps APIから取得
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAP_API_KEY'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20240803092248_add_place_to_boards.rb
+++ b/db/migrate/20240803092248_add_place_to_boards.rb
@@ -1,0 +1,7 @@
+class AddPlaceToBoards < ActiveRecord::Migration[7.1]
+  def change
+    add_column :boards, :place, :string
+    add_column :boards, :latitude, :float
+    add_column :boards, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_09_071925) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_03_092248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_071925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "board_image"
+    t.string "place"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_boards_on_user_id"
   end
 


### PR DESCRIPTION
## 投稿に訪れた場所を追加する機能を実装

#### 新規投稿作成フォームに追加したこと
``place``フィールド
・訪れた場所（住所やキーワード）を入力
・Google Place APIのオートコンプリート機能実装
・おおまかな場所を予測で出してくれる（現在日本のみ優先）

Board controller
・``strong palameter``に``:place``追加

#### オートコンプリート機能
Google Map JavaScript API 導入
Geocode API 導入

Google Place API 導入
・新規投稿フォームで読み込み
・オートコンプリートの設定をJSファイルで定義``app/javascript/place_autocomplete.js``

#### 投稿詳細画面で訪れた場所を確認できる（途中）
Boardsテーブルに以下カラム追加
・latitude（緯度）
・longitude（経度）
・place（訪れた場所）

gem "geocoder" 導入
・placeフィールドに入力された場所から緯度と経度を取得しDBに保存するため