### PR TITLE
プロフィール機能追加とレイアウト調整

### DIFF
--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,41 +1,44 @@
+<div class="md:px-32 lg:px-52">
 <%= form_with model: @board do |f| %>
-  <div class="my-3">
+  <div class="my-5">
     <p><%= f.label :place, '訪れた場所', class: "form-label" %></p>
-    <%= f.text_field :place, id: "Place", class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）国、県、市' %>
+    <%= f.text_field :place, id: "Place", class: "w-full border-solid border-2 rounded border-slate-400", placeholder: '例）国、県、市' %>
   </div>
-  <div class="my-3">
-    <div>
-      <%= f.label :board_image %>
-      <%= f.file_field :board_image, class: "form-control", accept: 'image/*' %>
-      <%= f.hidden_field :board_image_cache %>
+  <div class="my-5">
+    <%= f.label :board_image %>
+    <%= f.file_field :board_image, class: "form-control", accept: 'image/*' %>
+    <%= f.hidden_field :board_image_cache %>
 
-      <% if board.board_image.present? %>
-        <div class="mb-4 flex flex-row space-x-4">
-          <%= image_tag board.board_image.url, alt: "Current Image", class: "mt-2 block h-20 w-28" %>
-        </div>
-      <% end %>
-    </div>
-  <div class="my-3">
+    <% if board.board_image.present? %>
+      <div class="mb-4">
+        <%= image_tag board.board_image.url, alt: "Current Image", class: "mt-2 w-full" %>
+      </div>
+    <% end %>
+  </div>
+  <div class="my-5">
     <p><%= f.label :title, '旅で印象に残ったこと', class: "form-label" %></p>
-    <%= f.text_field :title, class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）大阪での発見' %>
+    <%= f.text_field :title, class: "w-full border-solid border-2 rounded border-slate-400", placeholder: '例）大阪での発見' %>
   </div>
-  <div class="my-3">
+  <div class="my-5">
     <p><%= f.label :opinion, 'なぜそれが特に印象に残ったのですか?', class: "form-label" %></p>
-    <%= f.text_area :opinion, class: "w-96 h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）大阪ではエスカレータは右に並ぶ' %>
+    <%= f.text_area :opinion, class: "w-full h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）大阪ではエスカレータは右に並ぶ' %>
   </div>
-  <div class="my-3">
+  <div class="my-5">
     <p><%= f.label :background, 'そのことに関連する自分の経験や背景を教えてください', class: "form-label" %></p>
-    <%= f.text_area :background, class: "w-96 h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）エスカレータで並ぶ時は世界共通で左だと思っていた' %>
+    <%= f.text_area :background, class: "w-full h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）エスカレータで並ぶ時は世界共通で左だと思っていた' %>
   </div>
-  <div class="my-3">
+  <div class="my-5">
     <p><%= f.label :emotion, 'その経験を通して、どんな感情や気持ちが湧きましたか?', class: "form-label" %></p>
-    <%= f.text_field :emotion, class: "w-96 border-solid border-2 rounded border-slate-400", placeholder: '例）驚き 面白い' %>
+    <%= f.text_field :emotion, class: "w-full border-solid border-2 rounded border-slate-400", placeholder: '例）驚き 面白い' %>
   </div>
-  <div class="my-3">
+  <div class="my-5">
     <p><%= f.label :value, 'この経験からあなたが学んだことや、重要だと思うことは?', class: "form-label" %></p>
-    <%= f.text_area :value, class: "w-96 h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）新しいことを知った時に面白いと思える' %>
+    <%= f.text_area :value, class: "w-full h-14 border-solid border-2 rounded border-slate-400", placeholder: '例）新しいことを知った時に面白いと思える' %>
   </div>
-  <%= f.submit '投稿', class: "btn btn-primary"%>
+  <div class="flex justify-center mt-10">
+    <%= f.submit '投稿', class: "btn"%>
+  </div>
 <% end %>
+</div>
 
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize"  async defer></script>

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,8 +1,12 @@
-<div class="flex justify-center items-center">
-<h3 class="lg:text-2xl my-10"><%= 'みんなの記事一覧' %></h3>
-</div>
-<% if @boards.present? %>
+<div>
+  <div class="px-10 mb-24">
+  <h3 class="lg:text-2xl lg:px-14 my-10"><%= 'みんなの記事一覧' %></h3>
+    <% if @boards.present? %>
+    <div class="flex-wrap sm:px-20 sm:grid grid-cols-2 lg:grid-cols-3 grid-rows-auto gap-5">
       <%= render @boards %>
+    </div>
     <% else %>
       <div class="mb-3">掲示板がありません</div>
     <% end %>
+  </div>
+</div>

--- a/app/views/boards/mypage.html.erb
+++ b/app/views/boards/mypage.html.erb
@@ -1,21 +1,25 @@
-<div class="py-6 sm:py-6 lg:py-2">
-  <div class="mx-auto py-3">
-  <h3 class="text-center lg:text-2xl my-10"><%= 'プロフィール' %></h3>
-    <div class="m-auto pt-10 text-center"><%= @current_user.name %></div>
-    <div class="m-auto pt-2 pb-5 text-center"><%= link_to 'プロフィール編集', profiles_path %></div>
+<div class="sm:px-20 py-6 sm:py-6 lg:py-2">
+  <div class="py-3 px-6">
+  <h3 class="text-1xl lg:text-2xl mb-2"><%= 'プロフィール' %></h3>
+    <div class="items-center px-5 py-5 flex gap-2 md:gap-5 bg-white border border-white rounded-lg">
+      <div class="text-lg"><%= '表示名' %></div>
+      <div class="text-slate-700"><%= @current_user.name %></div>
+      <div class="ml-auto md:mr-5"><%= link_to 'みる', profiles_path %></div>
+    </div>
   </div>
 </div>
 
-<div class="py-3 sm:py-8 lg:py-3">
-  <div class="mx-auto py-3">
-      <h3 class="text-center lg:text-2xl my-10"><%= '自分の記事一覧' %></h3>
+<div class="px-4 py-1 sm:py-8 lg:py-3">
+  <h3 class="px-2 sm:pl-24 lg:text-2xl my-2"><%= '自分の記事一覧' %></h3>
+
     <% if @boards.present? %>
+    <div class="flex-wrap sm:px-20 sm:grid grid-cols-2 lg:grid-cols-3 grid-rows-auto gap-5">
       <%= render @boards %>
+    </div>
     <% else %>
       <div class="m-auto pt-10 pb-20 text-center">掲示板がありません</div>
     <% end %>
     <div class="flex justify-center">
     <%= link_to '投稿する', new_board_path, class: 'btn'%>
     </div>
-  </div>
 </div>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,6 +1,6 @@
-<div class="flex justify-center items-center">
-  <div class="auto-rows-auto">
-<h3 class="lg:text-2xl mt-10"><%= '記事投稿' %></h3>
-<%= render 'form', board: @board %>
+<div>
+  <div class="px-10 mb-24">
+    <h3 class="lg:text-2xl md:px-32 lg:px-52 mt-10"><%= '記事投稿' %></h3>
+    <%= render 'form', board: @board %>
   </div>
 </div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
-<div class="px-4">
-<h3 class="my-6 text-2xl"><%= "#{@board.title}" %></h3>
+  <div class="px-5 mb-24 md:px-32 lg:px-52">
+    <h3 class="my-6 text-2xl"><%= "#{@board.title}" %></h3>
 
 <% if @board.board_image.present? %>
-    <%= image_tag @board.board_image_url, class: "object-contain" %>
+    <%= image_tag @board.board_image_url, class: "object-contain w-full" %>
 <% end %>
 
 <ul>
@@ -20,27 +20,28 @@
 <%= '投稿日時:' %>
 <%= l @board.created_at, format: :long %>
 </div></li>
+</ul>
 
 <p class="mb-1"><%= 'なぜそれが特に印象に残ったのですか?' %></p>
-<div class="w-96 mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
+<div class="w-full mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
 <%= simple_format(@board.opinion) %>
 </div>
 <p class="mb-1"><%= 'そのことに関連する自分の経験や背景' %></p>
-<div class="w-96 mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
+<div class="w-full mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
 <%= simple_format(@board.background) %>
 </div>
 <p class="mb-1"><%= 'その経験を通して、どんな感情や気持ちが湧きましたか?' %></p>
-<div class="w-96 mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
+<div class="w-full mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
 <%= simple_format(@board.emotion) %>
 </div>
 <p class="mb-1"><%= 'この経験からあなたが学んだことや、重要だと思うことは?' %></p>
-<div class="w-96 h-14 mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
+<div class="w-full h-14 mb-6 py-1 px-1 border-solid border-2 rounded border-slate-400">
 <%= simple_format(@board.value) %>
 </div>
 
 <%#　訪れた場所に入力がある場合に地図を表示する　%>
 <% if @board.place.present? %>
-  <div id="map" class="h-72 w-full md:w-9/12"></div>
+  <div id="map" class="h-60 w-full"></div>
 
 <script>
   // 地図を表示する関数
@@ -73,7 +74,8 @@
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
 <% end %>
-
-<%= link_to '一覧に戻る', boards_path, class: 'btn mt-3'%>
+  <div class="flex justify-center mt-10">
+  <%= link_to '一覧に戻る', boards_path, class: 'btn mt-3'%>
+  </div>
 </div>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,12 @@
-<%= form_with model: @user, url: profiles_path, method: :put do |f| %>
+<div class="px-6 mt-5 sm:px-24 mb-14">
+  <h2 class="text-1xl lg:text-2xl mb-2">表示名変更</h2>
+    <%= form_with model: @user, url: profiles_path, method: :put do |f| %>
   <div class="mb-3">
-    <%= f.label :name %>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.text_field :name, class: 'w-full px-5 py-5 bg-white border border-white rounded-lg' %>
   </div>
-  <%= f.submit class: "btn btn-primary" %>
-<% end %>
+  <div class="flex justify-center mx-auto">
+    <%= f.submit class: "btn text-slate-700 px-4 py-2 rounded-full text-sm" %>
+  </div>
+  <% end %>
+
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,18 @@
-設定
-表示名
-<%= @current_user.name%>
+<div class="px-6 sm:px-24 mb-14">
+  <h2 class="text-1xl lg:text-2xl mb-2">プロフィール設定</h2>
 
-<%= link_to '編集', edit_profiles_path, class: 'btn' %>
+    <div class="flex flex-col gap-6">
+    <div class="items-center px-5 py-5 bg-white border border-white rounded-lg">
+      <h3 class="text-lg pb-2"><%= '表示名' %></h3>
+      <div class="flex gap-2 md:gap-5">
+        <div class="pl-3 text-slate-700 text-sm"><%= @current_user.name %></div>
+        <div class="ml-auto mr-2 md:mr-5 text-sm"><%= link_to '編集', edit_profiles_path %></div>
+      </div>
+    </div>
+    <div class="bg-white px-5 py-5 border border-white rounded-lg">
+      <h3 class="text-lg"><%= 'メールアドレス' %></h3>
+      <div class="pl-3 pt-2 text-slate-700 text-sm"><%= @current_user.email %></div>
+    </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="text-[#302359] body-font bg-[#fbfbfb]">
-  <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
+  <div class="container mx-auto flex flex-wrap py-10 px-20 flex-col md:flex-row items-center">
   <%= link_to 'Jornalip', root_path, class: "mr-4 hover:text-gray-900" %>
     <%# link_to root_path, class: "flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0" do %>
       <%# ---左端にロゴ--- image_tag 'Journalip.png', class: 'w-full h-auto rounded', style: 'max-width: 300px; max-height: 200px;' %>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -8,10 +8,10 @@
     <h2 class="lg:text-4xl mb-24">旅からあなたの価値観を見つけ出そう</h2>
   </div>
 
-    <h4 class="text-center text-gray-800 font-bold mx-10 mb-4 text-xl md:mb-2">あなたが大事にしていることはなんですか？</h4>
-    <div class="text-gray-800 text-xs mx-10 md:text-base md:mx-44 lg:mx-96">
-      <p>そう聞かれた時に、うまく言葉にならなかった経験はありませんか？</p>
-      <p>Journalipは旅の思い出を通して、あなたらしさを言語化する練習を手伝います</p>
+    <h4 class="text-center text-gray-800 font-bold mx-10 mb-4 text-xl md:mb-2">旅行の感想 「楽しかった」 だけになってませんか？</h4>
+    <div class="text-center text-gray-800 text-xs mx-10 md:text-base md:mx-44 lg:mx-96">
+      <p></p>
+      <p>Journalipなら思い出を簡単に振り返ることができます</p>
     </div>
 
     <h2 class="mt-24 text-center text-2xl font-bold text-gray-800 mb-8 text-3xl">最新記事</h2>


### PR DESCRIPTION
## 概要
プロフィール機能追加
- 「マイページ」にプロフィールの一部を表示
- プロフィール詳細へのリンク設置
- 「プロフィール詳細」で表示名の「編集」ボタンを押すことで編集ページに遷移
- 今後、メールアドレス変更機能も追加予定

レイアウト調整
- トップページ：副題文変更
- ヘッダー：padding調整。文字を内側に移動。
- 新規投稿フォーム：レスポンシブ対応
- 投稿詳細ページ：レスポンシブ対応