### PR TITLE
AutoCompleteをリロードなしで利用できるようにした

### DIFF
--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -41,4 +41,4 @@
 <% end %>
 </div>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize"  async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize" async></script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
     <!-- Desktop Menu -->
     <nav class="text-xs md:flex md:ml-auto flex-nowrap items-center justify-center">
       <%= link_to 'マイページ', mypage_boards_path, class: "mr-4 hover:text-gray-900" %>
-      <%= link_to '投稿', new_board_path, class: "mr-4 hover:text-gray-900" %>
+      <%= link_to '投稿', new_board_path, data: { turbo: false }, class: "mr-4 hover:text-gray-900" %>
       <%= link_to '一覧', boards_path, class: "mr-4 hover:text-gray-900" %>
       <%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: "hover:text-gray-900" %>
     </nav>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -28,6 +28,6 @@
 
   <div class="flex justify-center py-24">
     <%= link_to 'もっと見る', boards_path, class: "btn" %>
-    <%= link_to '書いてみる', new_board_path, class: "btn ml-3" %>
+    <%= link_to '書いてみる', new_board_path, data: { turbo: false }, class: "btn ml-3" %>
   </div>
 </div>


### PR DESCRIPTION
#80 リロードしないとオートコンプリートが効かない問題 に対応

新規投稿ページへの遷移リンク（以下）に``{ turbo: false }``を追加
- ヘッダー＞「投稿」リンク
- トップページ下部「書いてみる」ボタン