### PR TITLE
GoogleMapsAPI読み込み修正

### DIFF
--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -41,4 +41,3 @@
 <% end %>
 </div>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize"  async defer></script>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -4,3 +4,6 @@
     <%= render 'form', board: @board %>
   </div>
 </div>
+
+<%# GoogleMapAPI読み込み %>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API_KEY"] %>&libraries=places&callback=initialize" defer></script>


### PR DESCRIPTION
#80 投稿フォームでリロードしないと訪れた場所のオートコンプリート機能が作動しないissueに対応

原因：API読み込みファイルの間違い
対応：``app/views/borders/_form.html.erb``に記載していたAPI読み込みコードを``app/views/borders/new.html.erb``へ移動することで、リロードなしでオートコンプリート機能が作動した