### PR TITLE
レイアウト調整

### DIFF
--- a/app/views/boards/mypage.html.erb
+++ b/app/views/boards/mypage.html.erb
@@ -4,7 +4,7 @@
     <div class="items-center px-5 py-5 flex gap-2 md:gap-5 bg-white border border-white rounded-lg">
       <div class="text-lg"><%= '表示名' %></div>
       <div class="text-slate-700"><%= @current_user.name %></div>
-      <div class="ml-auto md:mr-5"><%= link_to 'みる', profiles_path %></div>
+      <div class="ml-auto md:mr-5 hover:font-bold"><%= link_to 'みる', profiles_path %></div>
     </div>
   </div>
 </div>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag @board.board_image_url, class: "object-contain w-full" %>
 <% end %>
 
-  <h3 class="my-6 textxl"><%= "#{@board.title}" %></h3>
+  <h2 class="my-6 text-xl font-bold"><%= "#{@board.title}" %></h2>
 
 <ul>
   <li>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
 <div class="py-10 bg-[#fbfbfb]">
   <h1 class="px-10 md:px-16 text-base md:text-3xl font-medium">プライバシーポリシー</h1>
 </div>
-<div class="px-10 md:px-52 md:py-16 bg-white leading-8 flex flex-col">
+<div class="px-10 md:px-52 py-10 md:py-16 bg-white leading-8 flex flex-col">
 <p>「Jornalip」（以下，「本サイト」といいます。）は，本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。</p>
 
 <h2 class="pb-5 my-8 font-bold text-lg border-solid border-b border-slate-400">第1条（個人情報）</h2>

--- a/app/views/pages/terms_of_use.html.erb
+++ b/app/views/pages/terms_of_use.html.erb
@@ -1,7 +1,7 @@
 <div class="py-10 bg-[#fbfbfb]">
   <h1 class="px-10 md:px-16 text-base md:text-3xl font-medium">ご利用規約</h1>
 </div>
-<div class="px-10 md:px-52 md:py-16 bg-white leading-8 flex flex-col">
+<div class="px-10 md:px-52 py-10 md:py-16 bg-white leading-8 flex flex-col">
 <p>この利用規約（以下，「本規約」といいます。）は，Journalip（以下，「運営者」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
 
 <h2 class="pb-5 my-8 font-bold text-lg border-solid border-b border-slate-400">第1条（適用）</h2>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
         <h3 class="text-lg pb-2"><%= '表示名' %></h3>
         <div class="flex gap-2 md:gap-5">
           <p class="pl-3 text-slate-700 text-sm"><%= @current_user.name %></p>
-          <p class="ml-auto mr-2 md:mr-5 text-sm"><%= link_to '編集', edit_profiles_path %></p>
+          <p class="ml-auto mr-2 md:mr-5 text-sm hover:font-bold"><%= link_to '編集', edit_profiles_path %></p>
         </div>
       </div>
 

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="py-6 sm:py-8 lg:py-12">
+<div class="py-6 px-6 sm:py-8 lg:py-12">
   <div class="mx-auto py-9">
     <h2 class="mb-4 text-center text-2xl font-bold text-gray-800 md:mb-8 lg:text-3xl">ログイン</h2>
     <%= form_with url: login_path, class: "mx-auto max-w-lg rounded-lg border" do |f| %>


### PR DESCRIPTION
レスポンシブ対応
【スマホ】
・ログイン画面の枠左右に余白追加
・プライバシーポリシー、利用規約の上下余白追加

レイアウト調整
・投稿詳細のタイトル文字を太めに変更
・マイページプロフィール詳細ボタン、プロフィールページ編集ボタンをホバー時文字太めに強調する動き追加