### PR TITLE
ヘッダーデザイン修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,10 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    
+    <!-- OGP -->
     <%= display_meta_tags(default_meta_tags) %>
+    <!-- Font Awesome -->
+    <script src="https://kit.fontawesome.com/479ba9e980.js" crossorigin="anonymous"></script>
   </head>
 
   <body class="bg-[#fbfbfb]">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,16 +1,30 @@
 <header class="text-[#302359] body-font bg-[#fbfbfb]">
-  <div class="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
-    <%= link_to 'Jornalip', root_path, class: "mr-4 hover:text-gray-900" %>
+  <div class="container mx-auto flex flex-wrap py-10 px-8 lg:px-20 flex-row items-center">
+
+    <%= link_to 'Jornalip', root_path, class: "items-center mr-4 hover:text-gray-900 display:inine-block" %>
     <%# link_to root_path, class: "flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0" do %>
       <%# ---左端にロゴ--- image_tag 'Journalip.png', class: 'w-full h-auto rounded', style: 'max-width: 300px; max-height: 200px;' %>
     <%# end %>
+
     <!-- Desktop Menu -->
-    <nav class="text-xs md:flex md:ml-auto flex-nowrap items-center justify-center">
+    <div class="hidden lg:block text-xs md:flex md:ml-auto flex-nowrap items-center justify-center">
       <%= link_to 'ログイン', login_path, class: "mr-4 hover:font-bold" %>
       <%= link_to '会員登録', users_new_path, class: "mr-4 hover:font-bold" %>
       <%# link_to '検索', '#', class: "mr-4 hover:text-gray-900" %>
-      <%# link_to 'ログアウト', '#', data: { turbo_method: :delete }, class: "hover:text-gray-900" %>
-    </nav>
+    </div>
+
+    <!-- mobile Menu -->
+    <div class="text-xs md:hidden justify-center flex flex-col ml-auto">
+      <div class="dropdown dropdown-end">
+        <div tabindex="0" role="button" class="flex items-center py-5 px-3 text-sm rounded-lg hover:bg-gray-100">
+        <i class="fa-solid fa-bars fa-xl"></i>
+        </div>
+          <ul tabindex="0" class="dropdown-content z-[2] menu p-2 shadow bg-base-100 rounded-box w-52">
+            <li><%= link_to 'ログイン', login_path, class: "mr-4 hover:font-bold" %></li>
+            <li><%= link_to '会員登録', users_new_path, class: "mr-4 hover:font-bold" %></li>
+          </ul>
+      </div>
+    </div>
 
   </div>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,16 +1,32 @@
 <header class="text-[#302359] body-font bg-[#fbfbfb]">
-  <div class="container mx-auto flex flex-wrap py-10 px-20 flex-col md:flex-row items-center">
-  <%= link_to 'Jornalip', root_path, class: "mr-4 hover:text-gray-900" %>
+  <div class="container mx-auto flex flex-wrap py-10 px-8 lg:px-20 flex-row items-center">
+
+    <%= link_to 'Jornalip', root_path, class: "items-center mr-4 hover:text-gray-900 display:inine-block" %>
+
     <%# link_to root_path, class: "flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0" do %>
       <%# ---左端にロゴ--- image_tag 'Journalip.png', class: 'w-full h-auto rounded', style: 'max-width: 300px; max-height: 200px;' %>
     <%# end %>
-    <!-- Desktop Menu -->
-    <nav class="text-xs md:flex md:ml-auto flex-nowrap items-center justify-center">
+    <!-- tablet-Desktop Menu -->
+    <div class="hidden lg:block text-xs md:flex md:ml-auto flex-nowrap items-center justify-center">
       <%= link_to 'マイページ', mypage_boards_path, class: "mr-4 hover:font-bold" %>
       <%= link_to '投稿', new_board_path, data: { turbo: false }, class: "mr-4 hover:font-bold" %>
       <%= link_to '一覧', boards_path, class: "mr-4 hover:font-bold" %>
       <%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: "hover:font-bold" %>
-    </nav>
+    </div>
+
+    <!-- mobile Menu -->
+      <div class="text-xs md:hidden justify-center flex flex-col ml-auto">
+        <div class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="flex items-center py-5 px-3 text-sm rounded-lg hover:bg-gray-100">
+          <i class="fa-solid fa-bars fa-xl"></i>
+          </div>
+        <ul tabindex="0" class="dropdown-content z-[2] menu p-2 shadow bg-base-100 rounded-box w-52">
+          <li><%= link_to 'マイページ', mypage_boards_path, class: "mr-4 hover:font-bold" %></li>
+          <li><%= link_to '投稿', new_board_path, data: { turbo: false }, class: "mr-4 hover:font-bold" %></li>
+          <li><%= link_to '一覧', boards_path, class: "mr-4 hover:font-bold" %></li>
+          <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: "hover:font-bold" %></li>
+        </div>
+      </div>
 
   </div>
 </header>


### PR DESCRIPTION
・FontAwesom導入
・モバイル版ヘッダーはFontAwesomでアイコン表示に変更
・ブレイクポイント：タブレット以上は文字横並びで表示のまま継続