### PR TITLE
Xシェア時のOGP設定追加

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,4 +1,6 @@
 class BoardsController < ApplicationController
+  include ApplicationHelper
+
   before_action :set_board, only: %i[edit update destroy]
 
   def index
@@ -7,6 +9,10 @@ class BoardsController < ApplicationController
 
   def show
     @board = Board.find(params[:id])
+
+    # 動的OGP
+    image_path = ActionController::Base.helpers.image_url('Xcard.png')
+    set_board_meta_tags(@board, image_path)
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
     end
   end
 
-  # OGPで表示する具体的なサイト内容
+  # 基本的なOGPで表示する具体的なサイト内容
   def default_meta_tags
     {
       site: 'Journalip',
@@ -39,5 +39,24 @@ module ApplicationHelper
         image: image_url('Xcard.png'),
       }
     }
+  end
+
+  # 投稿記事毎の動的OGP（画像は固定）
+  def set_board_meta_tags(board, image_url)
+    set_meta_tags(
+      title: board.title,
+      description: "旅行の思い出を投稿しました！#{board.title}",
+      og: {
+        title: board.title,
+        description: "旅行の思い出を投稿しました！#{board.title}",
+        url: request.original_url,
+        image: image_url  # 固定画像
+      },
+      twitter: {
+        title: board.title,
+        description: "旅行の思い出を投稿しました！#{board.title}",
+        image: image_url # 固定画像
+      }
+    )
   end
 end

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -84,10 +84,17 @@
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
 <% end %>
 
-<div class="flex justify-center mt-10">
-    <%= link_to "https://twitter.com/intent/tweet?url=https://journalip.com/&text= \n旅行の思い出を投稿しました #Journalip \n", target: "_blank", rel: "noopener" do %>
-    <p class="btn"><i class="fa-brands fa-x-twitter font-bold fa-lg"></i>で共有する</p>
-  <% end %>
+<% if current_user && current_user.own?(@board) %>
+  <div class="flex justify-center mt-10">
+    <% share_text ="旅行の思い出を投稿しました！\n\n【#{@board.title}】\n#Journalip\n" %>
+    <% share_url = "https://journalip.com/boards/#{@board.id}" %>
+      <%= link_to "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(share_text)}&url=#{ERB::Util.url_encode(share_url)}", target: "_blank", rel: "noopener" do %>
+      <p class="btn"><i class="fa-brands fa-x-twitter font-bold fa-lg"></i>で共有する</p>
+      <% end %>
+<% end %>
+
+
+
 </div>
 <div class="flex justify-center mt-2">
   <%= link_to '一覧に戻る', boards_path, class: 'btn mt-3'%>


### PR DESCRIPTION
- [ ] 記事の投稿者のみXシェアボタン表示へ変更
- [ ] Xシェア時、以下をポストで表示させる
  - 「思い出を投稿しました！」テキスト
  - 【タイトル】➔動的に生成
  - 投稿記事URL ➔動的に生成
  - アプリのX用OGP画像（固定）
 
上記、本番環境で動作確認済み